### PR TITLE
 test: add comprehensive unit tests for AiSEG metric collectors

### DIFF
--- a/src/aiseg/client.rs
+++ b/src/aiseg/client.rs
@@ -61,7 +61,7 @@ mod tests {
     fn test_client_new() {
         let config = test_config();
         let client = Client::new(config);
-        
+
         assert_eq!(client.config.url, "http://test.local");
         assert_eq!(client.config.user, "test_user");
         assert_eq!(client.config.password, "test_password");
@@ -71,7 +71,7 @@ mod tests {
     async fn test_get_success() {
         let mut server = mockito::Server::new_async().await;
         let mock_url = server.url();
-        
+
         // Mock successful response
         let _mock = server
             .mock("GET", "/test/path")
@@ -85,10 +85,10 @@ mod tests {
             user: "test_user".to_string(),
             password: "test_password".to_string(),
         };
-        
+
         let client = Client::new(config);
         let result = client.get("/test/path").await;
-        
+
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "<html><body>Test Response</body></html>");
     }
@@ -97,7 +97,7 @@ mod tests {
     async fn test_get_404_error() {
         let mut server = mockito::Server::new_async().await;
         let mock_url = server.url();
-        
+
         // Mock 404 response
         let _mock = server
             .mock("GET", "/not/found")
@@ -111,13 +111,15 @@ mod tests {
             user: "test_user".to_string(),
             password: "test_password".to_string(),
         };
-        
+
         let client = Client::new(config);
         let result = client.get("/not/found").await;
-        
+
         assert!(result.is_err());
         let error = result.unwrap_err();
-        assert!(error.to_string().contains("Request failed with status: 404"));
+        assert!(error
+            .to_string()
+            .contains("Request failed with status: 404"));
         assert!(error.to_string().contains("Not Found"));
     }
 
@@ -125,7 +127,7 @@ mod tests {
     async fn test_get_500_error() {
         let mut server = mockito::Server::new_async().await;
         let mock_url = server.url();
-        
+
         // Mock 500 response
         let _mock = server
             .mock("GET", "/error")
@@ -139,13 +141,15 @@ mod tests {
             user: "test_user".to_string(),
             password: "test_password".to_string(),
         };
-        
+
         let client = Client::new(config);
         let result = client.get("/error").await;
-        
+
         assert!(result.is_err());
         let error = result.unwrap_err();
-        assert!(error.to_string().contains("Request failed with status: 500"));
+        assert!(error
+            .to_string()
+            .contains("Request failed with status: 500"));
         assert!(error.to_string().contains("Internal Server Error"));
     }
 
@@ -153,7 +157,7 @@ mod tests {
     async fn test_get_with_json_response() {
         let mut server = mockito::Server::new_async().await;
         let mock_url = server.url();
-        
+
         // Mock JSON response
         let _mock = server
             .mock("GET", "/api/data")
@@ -167,10 +171,10 @@ mod tests {
             user: "test_user".to_string(),
             password: "test_password".to_string(),
         };
-        
+
         let client = Client::new(config);
         let result = client.get("/api/data").await;
-        
+
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), r#"{"status":"ok","value":123.45}"#);
     }
@@ -179,7 +183,7 @@ mod tests {
     async fn test_get_with_html_response() {
         let mut server = mockito::Server::new_async().await;
         let mock_url = server.url();
-        
+
         // Mock HTML response with Japanese characters
         let html_body = r#"
             <html>
@@ -189,7 +193,7 @@ mod tests {
                 </body>
             </html>
         "#;
-        
+
         let _mock = server
             .mock("GET", "/page/electricflow/111")
             .with_status(200)
@@ -202,10 +206,10 @@ mod tests {
             user: "test_user".to_string(),
             password: "test_password".to_string(),
         };
-        
+
         let client = Client::new(config);
         let result = client.get("/page/electricflow/111").await;
-        
+
         assert!(result.is_ok());
         let body = result.unwrap();
         assert!(body.contains("g_capacity"));
@@ -221,11 +225,14 @@ mod tests {
             user: "test_user".to_string(),
             password: "test_password".to_string(),
         };
-        
+
         let client = Client::new(config);
         let result = client.get("/test").await;
-        
+
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Failed to send GET request"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to send GET request"));
     }
 }

--- a/src/aiseg/daily_total_metric_collector.rs
+++ b/src/aiseg/daily_total_metric_collector.rs
@@ -90,3 +90,498 @@ fn make_query(date: DateTime<Local>) -> String {
     );
     STANDARD.encode(query)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config;
+    use chrono::TimeZone;
+    use mockito;
+
+    fn test_config(url: String) -> config::Aiseg2Config {
+        config::Aiseg2Config {
+            url,
+            user: "test_user".to_string(),
+            password: "test_password".to_string(),
+        }
+    }
+
+    fn create_html_response(title: &str, value: &str) -> String {
+        format!(
+            r#"<html><body>
+                <div id="h_title">{}</div>
+                <div id="val_kwh">{}</div>
+            </body></html>"#,
+            title, value
+        )
+    }
+
+    #[test]
+    fn test_make_query() {
+        let date = Local.with_ymd_and_hms(2024, 6, 6, 10, 30, 0).unwrap();
+        let query = make_query(date);
+        
+        // Decode the base64 to verify the JSON content
+        let decoded = String::from_utf8(STANDARD.decode(&query).unwrap()).unwrap();
+        let expected = r#"{"day":[2024, 6, 6],"month_compare":"mon","day_compare":"day"}"#;
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn test_make_query_handles_different_dates() {
+        // Test leap year date
+        let date1 = Local.with_ymd_and_hms(2024, 2, 29, 0, 0, 0).unwrap();
+        let query1 = make_query(date1);
+        let decoded1 = String::from_utf8(STANDARD.decode(&query1).unwrap()).unwrap();
+        assert!(decoded1.contains(r#""day":[2024, 2, 29]"#));
+        assert!(decoded1.contains(r#""month_compare":"mon"#));
+        assert!(decoded1.contains(r#""day_compare":"day"#));
+
+        // Test beginning of year
+        let date2 = Local.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let query2 = make_query(date2);
+        let decoded2 = String::from_utf8(STANDARD.decode(&query2).unwrap()).unwrap();
+        assert!(decoded2.contains(r#""day":[2024, 1, 1]"#));
+
+        // Test end of year
+        let date3 = Local.with_ymd_and_hms(2023, 12, 31, 23, 59, 59).unwrap();
+        let query3 = make_query(date3);
+        let decoded3 = String::from_utf8(STANDARD.decode(&query3).unwrap()).unwrap();
+        assert!(decoded3.contains(r#""day":[2023, 12, 31]"#));
+    }
+
+    mod succeeds {
+        use super::*;
+
+        #[tokio::test]
+        async fn test_collect_by_graph_id_parses_valid_html() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+            
+            let date = Local.with_ymd_and_hms(2024, 6, 6, 10, 0, 0).unwrap();
+            let expected_query = make_query(day_of_beginning(&date));
+            
+            let _mock = server
+                .mock("GET", format!("/page/graph/51111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(create_html_response("太陽光発電量", "123.45"))
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result = collector
+                .collect_by_graph_id(date, "51111", Unit::Kwh)
+                .await;
+            
+            assert!(result.is_ok());
+            let metric = result.unwrap();
+            assert_eq!(metric.value, 123.45);
+            assert_eq!(metric.name, "太陽光発電量(kWh)");
+            assert_eq!(metric.measurement, Measurement::DailyTotal);
+            assert_eq!(metric.date, day_of_beginning(&date));
+        }
+
+        #[tokio::test]
+        async fn test_collect_by_graph_id_returns_correct_metric() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+            
+            let date = Local.with_ymd_and_hms(2024, 6, 6, 15, 30, 45).unwrap();
+            let expected_date = day_of_beginning(&date);
+            let expected_query = make_query(expected_date);
+            
+            let _mock = server
+                .mock("GET", format!("/page/graph/52111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(create_html_response("消費電力量", "456.78"))
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result = collector
+                .collect_by_graph_id(date, "52111", Unit::Kwh)
+                .await;
+            
+            assert!(result.is_ok());
+            let metric = result.unwrap();
+            assert_eq!(metric.measurement, Measurement::DailyTotal);
+            assert_eq!(metric.name, "消費電力量(kWh)");
+            assert_eq!(metric.value, 456.78);
+            assert_eq!(metric.date, expected_date);
+        }
+
+        #[tokio::test]
+        async fn test_collect_by_graph_id_handles_different_units() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+            
+            let date = Local::now();
+            let expected_query = make_query(day_of_beginning(&date));
+            
+            // Test kWh unit
+            let _mock1 = server
+                .mock("GET", format!("/page/graph/51111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(create_html_response("電力", "100.0"))
+                .create_async()
+                .await;
+            
+            let config = test_config(mock_url.clone());
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result1 = collector
+                .collect_by_graph_id(date, "51111", Unit::Kwh)
+                .await;
+            assert!(result1.is_ok());
+            assert_eq!(result1.unwrap().name, "電力(kWh)");
+            
+            // Test Liter unit
+            let _mock2 = server
+                .mock("GET", format!("/page/graph/55111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(create_html_response("給湯量", "200.5"))
+                .create_async()
+                .await;
+            
+            let config = test_config(mock_url.clone());
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result2 = collector
+                .collect_by_graph_id(date, "55111", Unit::Liter)
+                .await;
+            assert!(result2.is_ok());
+            assert_eq!(result2.unwrap().name, "給湯量(L)");
+            
+            // Test CubicMeter unit
+            let _mock3 = server
+                .mock("GET", format!("/page/graph/57111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(create_html_response("ガス使用量", "15.3"))
+                .create_async()
+                .await;
+            
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result3 = collector
+                .collect_by_graph_id(date, "57111", Unit::CubicMeter)
+                .await;
+            assert!(result3.is_ok());
+            assert_eq!(result3.unwrap().name, "ガス使用量(㎥)");
+        }
+
+        #[tokio::test]
+        async fn test_collect_returns_all_six_metrics() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+            
+            let date = Local::now();
+            let expected_date = day_of_beginning(&date);
+            let expected_query = make_query(expected_date);
+            
+            // Mock all six metric responses
+            let metrics = vec![
+                ("51111", "発電量", "100.0"),
+                ("52111", "消費量", "200.0"),
+                ("53111", "買電量", "50.0"),
+                ("54111", "売電量", "75.0"),
+                ("55111", "給湯量", "300.0"),
+                ("57111", "ガス量", "25.5"),
+            ];
+            
+            for (graph_id, title, value) in &metrics {
+                let _mock = server
+                    .mock("GET", format!("/page/graph/{}?data={}", graph_id, expected_query).as_str())
+                    .with_status(200)
+                    .with_body(create_html_response(title, value))
+                    .create_async()
+                    .await;
+            }
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result = collector.collect(date).await;
+            
+            assert!(result.is_ok());
+            let data_points = result.unwrap();
+            assert_eq!(data_points.len(), 6);
+            
+            // Verify each data point can be converted to InfluxDB format
+            for dp in data_points {
+                assert!(dp.to_point().is_ok());
+            }
+        }
+
+        #[tokio::test]
+        async fn test_collect_with_mixed_values() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+            
+            let date = Local::now();
+            let expected_date = day_of_beginning(&date);
+            let expected_query = make_query(expected_date);
+            
+            // Mock responses with different values including edge cases
+            let _mock1 = server
+                .mock("GET", format!("/page/graph/51111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(create_html_response("発電", "0.0"))
+                .create_async()
+                .await;
+            
+            let _mock2 = server
+                .mock("GET", format!("/page/graph/52111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(create_html_response("消費", "999.999"))
+                .create_async()
+                .await;
+            
+            let _mock3 = server
+                .mock("GET", format!("/page/graph/53111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(create_html_response("買電", "1"))
+                .create_async()
+                .await;
+            
+            let _mock4 = server
+                .mock("GET", format!("/page/graph/54111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(create_html_response("売電", "0.001"))
+                .create_async()
+                .await;
+            
+            let _mock5 = server
+                .mock("GET", format!("/page/graph/55111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(create_html_response("給湯", "1234.5678"))
+                .create_async()
+                .await;
+            
+            let _mock6 = server
+                .mock("GET", format!("/page/graph/57111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(create_html_response("ガス", "99.99"))
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result = collector.collect(date).await;
+            
+            assert!(result.is_ok());
+            let data_points = result.unwrap();
+            assert_eq!(data_points.len(), 6);
+        }
+    }
+
+    mod fails {
+        use super::*;
+
+        #[tokio::test]
+        async fn test_collect_by_graph_id_missing_h_title() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+            
+            let date = Local::now();
+            let expected_query = make_query(day_of_beginning(&date));
+            
+            // HTML without #h_title element
+            let html_without_title = r#"<html><body><div id="val_kwh">123.45</div></body></html>"#;
+            
+            let _mock = server
+                .mock("GET", format!("/page/graph/51111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(html_without_title)
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result = collector
+                .collect_by_graph_id(date, "51111", Unit::Kwh)
+                .await;
+            
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("Failed to find value"));
+        }
+
+        #[tokio::test]
+        async fn test_collect_by_graph_id_missing_val_kwh() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+            
+            let date = Local::now();
+            let expected_query = make_query(day_of_beginning(&date));
+            
+            // HTML without #val_kwh element
+            let html_without_val = r#"<html><body><div id="h_title">Test Title</div></body></html>"#;
+            
+            let _mock = server
+                .mock("GET", format!("/page/graph/51111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(html_without_val)
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result = collector
+                .collect_by_graph_id(date, "51111", Unit::Kwh)
+                .await;
+            
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("Failed to find value"));
+        }
+
+        #[tokio::test]
+        async fn test_collect_by_graph_id_invalid_numeric_value() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+            
+            let date = Local::now();
+            let expected_query = make_query(day_of_beginning(&date));
+            
+            // HTML with non-numeric value
+            let _mock = server
+                .mock("GET", format!("/page/graph/51111?data={}", expected_query).as_str())
+                .with_status(200)
+                .with_body(create_html_response("Title", "not-a-number"))
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result = collector
+                .collect_by_graph_id(date, "51111", Unit::Kwh)
+                .await;
+            
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("Failed to parse value"));
+        }
+
+        #[tokio::test]
+        async fn test_collect_by_graph_id_http_error() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+            
+            let date = Local::now();
+            let expected_query = make_query(day_of_beginning(&date));
+            
+            let _mock = server
+                .mock("GET", format!("/page/graph/51111?data={}", expected_query).as_str())
+                .with_status(500)
+                .with_body("Internal Server Error")
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result = collector
+                .collect_by_graph_id(date, "51111", Unit::Kwh)
+                .await;
+            
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("Request failed with status: 500"));
+        }
+
+        #[tokio::test]
+        async fn test_collect_one_metric_fails() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+            
+            let date = Local::now();
+            let expected_date = day_of_beginning(&date);
+            let expected_query = make_query(expected_date);
+            
+            // First five metrics succeed
+            let success_metrics = vec![
+                ("51111", "発電", "100.0"),
+                ("52111", "消費", "200.0"),
+                ("53111", "買電", "50.0"),
+                ("54111", "売電", "75.0"),
+                ("55111", "給湯", "300.0"),
+            ];
+            
+            for (graph_id, title, value) in &success_metrics {
+                let _mock = server
+                    .mock("GET", format!("/page/graph/{}?data={}", graph_id, expected_query).as_str())
+                    .with_status(200)
+                    .with_body(create_html_response(title, value))
+                    .create_async()
+                    .await;
+            }
+            
+            // Last metric fails
+            let _mock_fail = server
+                .mock("GET", format!("/page/graph/57111?data={}", expected_query).as_str())
+                .with_status(404)
+                .with_body("Not Found")
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result = collector.collect(date).await;
+            
+            // The collect method should fail if any metric fails
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn test_collect_all_metrics_fail() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+            
+            let date = Local::now();
+            let expected_date = day_of_beginning(&date);
+            let expected_query = make_query(expected_date);
+            
+            // All metrics return errors
+            let graph_ids = vec!["51111", "52111", "53111", "54111", "55111", "57111"];
+            
+            for graph_id in graph_ids {
+                let _mock = server
+                    .mock("GET", format!("/page/graph/{}?data={}", graph_id, expected_query).as_str())
+                    .with_status(503)
+                    .with_body("Service Unavailable")
+                    .create_async()
+                    .await;
+            }
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = DailyTotalMetricCollector::new(client);
+            
+            let result = collector.collect(date).await;
+            
+            assert!(result.is_err());
+            match result {
+                Err(e) => assert!(e.to_string().contains("Request failed with status: 503")),
+                Ok(_) => panic!("Expected error but got success"),
+            }
+        }
+    }
+}

--- a/src/aiseg/power_metric_collector.rs
+++ b/src/aiseg/power_metric_collector.rs
@@ -156,3 +156,747 @@ impl MetricCollector for PowerMetricCollector {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config;
+    use mockito;
+
+    fn test_config(url: String) -> config::Aiseg2Config {
+        config::Aiseg2Config {
+            url,
+            user: "test_user".to_string(),
+            password: "test_password".to_string(),
+        }
+    }
+
+    fn create_main_page_html(
+        g_capacity: &str,
+        u_capacity: &str,
+        details: Vec<(&str, &str)>,
+    ) -> String {
+        let mut html = format!(
+            r#"<html><body>
+                <div id="g_capacity">{}</div>
+                <div id="u_capacity">{}</div>"#,
+            g_capacity, u_capacity
+        );
+
+        for (i, (name, capacity)) in details.iter().enumerate() {
+            html.push_str(&format!(
+                r#"
+                <div id="g_d_{}_title"><span>{}</span></div>
+                <div id="g_d_{}_capacity"><span>{}</span></div>"#,
+                i + 1,
+                name,
+                i + 1,
+                capacity
+            ));
+        }
+
+        html.push_str("</body></html>");
+        html
+    }
+
+    fn create_consumption_page_html(items: Vec<(&str, &str)>) -> String {
+        let mut html = r#"<html><body>"#.to_string();
+
+        for (i, (device, value)) in items.iter().enumerate() {
+            html.push_str(&format!(
+                r#"
+                <div id="stage_{}">
+                    <div class="c_device"><span>{}</span></div>
+                    <div class="c_value"><span>{}</span></div>
+                </div>"#,
+                i + 1,
+                device,
+                value
+            ));
+        }
+
+        html.push_str("</body></html>");
+        html
+    }
+
+    mod succeeds {
+        use super::*;
+
+        #[test]
+        fn test_collect_total_metrics_valid_html() {
+            let html = create_main_page_html("2.5", "3.8", vec![]);
+            let document = Html::parse_document(&html);
+            let collector = PowerMetricCollector::new(Arc::new(Client::new(test_config(
+                "http://test".to_string(),
+            ))));
+
+            let result = collector.collect_total_metrics(&document);
+
+            assert!(result.is_ok());
+            let metrics = result.unwrap();
+            assert_eq!(metrics.len(), 3);
+
+            // Verify all metrics can be converted to InfluxDB format
+            for metric in &metrics {
+                assert!(metric.to_point().is_ok());
+            }
+        }
+
+        #[test]
+        fn test_collect_generation_detail_metrics_valid_html() {
+            let html = create_main_page_html(
+                "2.5",
+                "3.8",
+                vec![
+                    ("太陽光", "2.5"),
+                    ("燃料電池", "0.5"),
+                    ("蓄電池", "0.2"),
+                    ("その他", "0.1"),
+                ],
+            );
+            let document = Html::parse_document(&html);
+            let collector = PowerMetricCollector::new(Arc::new(Client::new(test_config(
+                "http://test".to_string(),
+            ))));
+
+            let result = collector.collect_generation_detail_metrics(&document);
+
+            assert!(result.is_ok());
+            let metrics = result.unwrap();
+            assert_eq!(metrics.len(), 4);
+
+            // Verify all metrics can be converted to InfluxDB format
+            for metric in &metrics {
+                assert!(metric.to_point().is_ok());
+            }
+        }
+
+        #[test]
+        fn test_collect_generation_detail_metrics_partial() {
+            let html =
+                create_main_page_html("2.5", "3.8", vec![("太陽光", "2.5"), ("燃料電池", "0.5")]);
+            let document = Html::parse_document(&html);
+            let collector = PowerMetricCollector::new(Arc::new(Client::new(test_config(
+                "http://test".to_string(),
+            ))));
+
+            let result = collector.collect_generation_detail_metrics(&document);
+
+            assert!(result.is_ok());
+            let metrics = result.unwrap();
+            assert_eq!(metrics.len(), 2); // Only 2 items found
+        }
+
+        #[test]
+        fn test_collect_total_metrics_calculates_sell_buy_power() {
+            let test_cases = vec![
+                ("5.0", "3.0", 2000),  // Selling power (positive)
+                ("2.0", "4.0", -2000), // Buying power (negative)
+                ("3.0", "3.0", 0),     // Balanced (zero)
+            ];
+
+            for (generation, consumption, _expected_sell_buy) in test_cases {
+                let html = create_main_page_html(generation, consumption, vec![]);
+                let document = Html::parse_document(&html);
+                let collector = PowerMetricCollector::new(Arc::new(Client::new(test_config(
+                    "http://test".to_string(),
+                ))));
+
+                let result = collector.collect_total_metrics(&document);
+                assert!(result.is_ok());
+                let metrics = result.unwrap();
+                assert_eq!(metrics.len(), 3);
+
+                // Verify the sell/buy metric exists and can be converted
+                assert!(metrics[2].to_point().is_ok());
+            }
+        }
+
+        #[tokio::test]
+        async fn test_collect_from_main_page_complete_data() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            let _mock = server
+                .mock("GET", "/page/electricflow/111")
+                .with_status(200)
+                .with_body(create_main_page_html(
+                    "2.5",
+                    "3.8",
+                    vec![("太陽光", "2.5"), ("燃料電池", "0.0")],
+                ))
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect_from_main_page().await;
+
+            assert!(result.is_ok());
+            let metrics = result.unwrap();
+            assert_eq!(metrics.len(), 5); // 3 total metrics + 2 generation details
+        }
+
+        #[tokio::test]
+        async fn test_collect_consumption_single_page() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            // Page 1 with data
+            let _mock1 = server
+                .mock("GET", "/page/electricflow/1113?id=1")
+                .with_status(200)
+                .with_body(create_consumption_page_html(vec![
+                    ("エアコン", "1.2"),
+                    ("冷蔵庫", "0.3"),
+                    ("照明", "0.1"),
+                ]))
+                .create_async()
+                .await;
+
+            // Pages 2-20 empty to trigger termination on empty page
+            for page in 2..=20 {
+                let _ = server
+                    .mock(
+                        "GET",
+                        format!("/page/electricflow/1113?id={}", page).as_str(),
+                    )
+                    .with_status(200)
+                    .with_body(create_consumption_page_html(vec![]))
+                    .create_async()
+                    .await;
+            }
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect_consumption_detail_metrics().await;
+
+            assert!(result.is_ok());
+            let metrics = result.unwrap();
+            assert_eq!(metrics.len(), 3);
+
+            for metric in metrics {
+                assert!(metric.to_point().is_ok());
+            }
+        }
+
+        #[tokio::test]
+        async fn test_collect_consumption_multiple_pages() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            // Page 1
+            let page1_items = vec![
+                ("Device1", "0.1"),
+                ("Device2", "0.1"),
+                ("Device3", "0.1"),
+                ("Device4", "0.1"),
+                ("Device5", "0.1"),
+                ("Device6", "0.1"),
+                ("Device7", "0.1"),
+                ("Device8", "0.1"),
+                ("Device9", "0.1"),
+                ("Device10", "0.1"),
+            ];
+            let _mock1 = server
+                .mock("GET", "/page/electricflow/1113?id=1")
+                .with_status(200)
+                .with_body(create_consumption_page_html(page1_items))
+                .create_async()
+                .await;
+
+            // Page 2
+            let page2_items = vec![
+                ("Device11", "0.2"),
+                ("Device12", "0.2"),
+                ("Device13", "0.2"),
+                ("Device14", "0.2"),
+                ("Device15", "0.2"),
+            ];
+            let _mock2 = server
+                .mock("GET", "/page/electricflow/1113?id=2")
+                .with_status(200)
+                .with_body(create_consumption_page_html(page2_items))
+                .create_async()
+                .await;
+
+            // Pages 3-20 empty
+            for page in 3..=20 {
+                let _ = server
+                    .mock(
+                        "GET",
+                        format!("/page/electricflow/1113?id={}", page).as_str(),
+                    )
+                    .with_status(200)
+                    .with_body(create_consumption_page_html(vec![]))
+                    .create_async()
+                    .await;
+            }
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect_consumption_detail_metrics().await;
+
+            assert!(result.is_ok());
+            let metrics = result.unwrap();
+            assert_eq!(metrics.len(), 15); // 10 from page 1 + 5 from page 2
+        }
+
+        #[tokio::test]
+        async fn test_collect_consumption_stops_on_duplicate() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            let items = vec![("エアコン", "1.2"), ("冷蔵庫", "0.3")];
+
+            // Page 1
+            let _mock1 = server
+                .mock("GET", "/page/electricflow/1113?id=1")
+                .with_status(200)
+                .with_body(create_consumption_page_html(items.clone()))
+                .create_async()
+                .await;
+
+            // Page 2 with same items (duplicate names)
+            let _mock2 = server
+                .mock("GET", "/page/electricflow/1113?id=2")
+                .with_status(200)
+                .with_body(create_consumption_page_html(items))
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect_consumption_detail_metrics().await;
+
+            assert!(result.is_ok());
+            let metrics = result.unwrap();
+            assert_eq!(metrics.len(), 2); // Only first page's items
+        }
+
+        #[tokio::test]
+        async fn test_collect_consumption_merges_duplicates() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            // Page 1 with duplicate "エアコン"
+            let _mock1 = server
+                .mock("GET", "/page/electricflow/1113?id=1")
+                .with_status(200)
+                .with_body(create_consumption_page_html(vec![
+                    ("エアコン", "1.2"),
+                    ("冷蔵庫", "0.3"),
+                    ("エアコン", "0.8"), // Duplicate
+                ]))
+                .create_async()
+                .await;
+
+            // Pages 2-20 empty
+            for page in 2..=20 {
+                let _ = server
+                    .mock(
+                        "GET",
+                        format!("/page/electricflow/1113?id={}", page).as_str(),
+                    )
+                    .with_status(200)
+                    .with_body(create_consumption_page_html(vec![]))
+                    .create_async()
+                    .await;
+            }
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect_consumption_detail_metrics().await;
+
+            assert!(result.is_ok());
+            let metrics = result.unwrap();
+            assert_eq!(metrics.len(), 2); // Merged to 2 unique items
+
+            // Verify all metrics can be converted
+            for metric in metrics {
+                assert!(metric.to_point().is_ok());
+            }
+        }
+
+        #[tokio::test]
+        async fn test_collect_consumption_handles_zero_watt() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            let _mock1 = server
+                .mock("GET", "/page/electricflow/1113?id=1")
+                .with_status(200)
+                .with_body(create_consumption_page_html(vec![
+                    ("エアコン", "1.2"),
+                    ("冷蔵庫", "invalid"), // Will default to 0
+                    ("照明", "0.5"),
+                ]))
+                .create_async()
+                .await;
+
+            // Pages 2-20 empty
+            for page in 2..=20 {
+                let _ = server
+                    .mock(
+                        "GET",
+                        format!("/page/electricflow/1113?id={}", page).as_str(),
+                    )
+                    .with_status(200)
+                    .with_body(create_consumption_page_html(vec![]))
+                    .create_async()
+                    .await;
+            }
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect_consumption_detail_metrics().await;
+
+            assert!(result.is_ok());
+            let metrics = result.unwrap();
+            assert_eq!(metrics.len(), 3);
+
+            // Verify all metrics can be converted
+            for metric in metrics {
+                assert!(metric.to_point().is_ok());
+            }
+        }
+
+        #[tokio::test]
+        async fn test_collect_returns_all_metrics() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            // Mock main page
+            let _mock_main = server
+                .mock("GET", "/page/electricflow/111")
+                .with_status(200)
+                .with_body(create_main_page_html("2.5", "3.8", vec![("太陽光", "2.5")]))
+                .create_async()
+                .await;
+
+            // Mock consumption page
+            let _mock_cons1 = server
+                .mock("GET", "/page/electricflow/1113?id=1")
+                .with_status(200)
+                .with_body(create_consumption_page_html(vec![
+                    ("エアコン", "1.2"),
+                    ("冷蔵庫", "0.3"),
+                ]))
+                .create_async()
+                .await;
+
+            // Pages 2-20 empty
+            for page in 2..=20 {
+                let _ = server
+                    .mock(
+                        "GET",
+                        format!("/page/electricflow/1113?id={}", page).as_str(),
+                    )
+                    .with_status(200)
+                    .with_body(create_consumption_page_html(vec![]))
+                    .create_async()
+                    .await;
+            }
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect(Local::now()).await;
+
+            assert!(result.is_ok());
+            let metrics = result.unwrap();
+            assert_eq!(metrics.len(), 6); // 3 total + 1 generation detail + 2 consumption
+
+            // Verify all can be converted to InfluxDB format
+            for metric in metrics {
+                assert!(metric.to_point().is_ok());
+            }
+        }
+
+        #[tokio::test]
+        async fn test_collect_with_various_values() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            // Mock main page with edge case values
+            let _mock_main = server
+                .mock("GET", "/page/electricflow/111")
+                .with_status(200)
+                .with_body(create_main_page_html(
+                    "0.001",  // Very small
+                    "99.999", // Large value
+                    vec![("太陽光", "12.345"), ("燃料電池", "0.0")],
+                ))
+                .create_async()
+                .await;
+
+            // Mock consumption with various values
+            let _mock_cons1 = server
+                .mock("GET", "/page/electricflow/1113?id=1")
+                .with_status(200)
+                .with_body(create_consumption_page_html(vec![
+                    ("Device1", "0.0"),
+                    ("Device2", "1.999"),
+                    ("Device3", "50.5"),
+                ]))
+                .create_async()
+                .await;
+
+            // Pages 2-20 empty
+            for page in 2..=20 {
+                let _ = server
+                    .mock(
+                        "GET",
+                        format!("/page/electricflow/1113?id={}", page).as_str(),
+                    )
+                    .with_status(200)
+                    .with_body(create_consumption_page_html(vec![]))
+                    .create_async()
+                    .await;
+            }
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect(Local::now()).await;
+
+            assert!(result.is_ok());
+            let metrics = result.unwrap();
+            assert!(metrics.len() > 0);
+        }
+    }
+
+    mod fails {
+        use super::*;
+
+        #[test]
+        fn test_collect_total_metrics_missing_g_capacity() {
+            let html = r#"<html><body><div id="u_capacity">3.8</div></body></html>"#;
+            let document = Html::parse_document(&html);
+            let collector = PowerMetricCollector::new(Arc::new(Client::new(test_config(
+                "http://test".to_string(),
+            ))));
+
+            let result = collector.collect_total_metrics(&document);
+
+            assert!(result.is_err());
+            match result {
+                Err(e) => assert!(e.to_string().contains("Failed to find value")),
+                Ok(_) => panic!("Expected error but got success"),
+            }
+        }
+
+        #[test]
+        fn test_collect_total_metrics_missing_u_capacity() {
+            let html = r#"<html><body><div id="g_capacity">2.5</div></body></html>"#;
+            let document = Html::parse_document(&html);
+            let collector = PowerMetricCollector::new(Arc::new(Client::new(test_config(
+                "http://test".to_string(),
+            ))));
+
+            let result = collector.collect_total_metrics(&document);
+
+            assert!(result.is_err());
+            match result {
+                Err(e) => assert!(e.to_string().contains("Failed to find value")),
+                Ok(_) => panic!("Expected error but got success"),
+            }
+        }
+
+        #[test]
+        fn test_collect_total_metrics_invalid_numeric() {
+            let html = r#"<html><body>
+                <div id="g_capacity">invalid</div>
+                <div id="u_capacity">3.8</div>
+            </body></html>"#;
+            let document = Html::parse_document(&html);
+            let collector = PowerMetricCollector::new(Arc::new(Client::new(test_config(
+                "http://test".to_string(),
+            ))));
+
+            let result = collector.collect_total_metrics(&document);
+
+            assert!(result.is_err());
+            match result {
+                Err(e) => assert!(e.to_string().contains("Failed to parse value")),
+                Ok(_) => panic!("Expected error but got success"),
+            }
+        }
+
+        #[tokio::test]
+        async fn test_collect_from_main_page_http_error() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            let _mock = server
+                .mock("GET", "/page/electricflow/111")
+                .with_status(500)
+                .with_body("Internal Server Error")
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect_from_main_page().await;
+
+            assert!(result.is_err());
+            match result {
+                Err(e) => assert!(e.to_string().contains("Request failed with status: 500")),
+                Ok(_) => panic!("Expected error but got success"),
+            }
+        }
+
+        #[tokio::test]
+        async fn test_collect_consumption_http_error() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            let _mock = server
+                .mock("GET", "/page/electricflow/1113?id=1")
+                .with_status(404)
+                .with_body("Not Found")
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect_consumption_detail_metrics().await;
+
+            assert!(result.is_err());
+            match result {
+                Err(e) => assert!(e.to_string().contains("Request failed with status: 404")),
+                Ok(_) => panic!("Expected error but got success"),
+            }
+        }
+
+        #[tokio::test]
+        async fn test_collect_consumption_empty_page() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            // First page is empty
+            let _mock = server
+                .mock("GET", "/page/electricflow/1113?id=1")
+                .with_status(200)
+                .with_body(create_consumption_page_html(vec![]))
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect_consumption_detail_metrics().await;
+
+            assert!(result.is_ok());
+            let metrics = result.unwrap();
+            assert_eq!(metrics.len(), 0); // No items collected
+        }
+
+        #[tokio::test]
+        async fn test_collect_main_page_fails() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            // Main page fails
+            let _mock_main = server
+                .mock("GET", "/page/electricflow/111")
+                .with_status(503)
+                .with_body("Service Unavailable")
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect(Local::now()).await;
+
+            assert!(result.is_err());
+            // Should fail fast on main page error
+            match result {
+                Err(e) => assert!(e.to_string().contains("Request failed with status: 503")),
+                Ok(_) => panic!("Expected error but got success"),
+            }
+        }
+
+        #[tokio::test]
+        async fn test_collect_consumption_fails() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            // Main page succeeds
+            let _mock_main = server
+                .mock("GET", "/page/electricflow/111")
+                .with_status(200)
+                .with_body(create_main_page_html("2.5", "3.8", vec![]))
+                .create_async()
+                .await;
+
+            // Consumption page fails
+            let _mock_cons = server
+                .mock("GET", "/page/electricflow/1113?id=1")
+                .with_status(500)
+                .with_body("Internal Server Error")
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect(Local::now()).await;
+
+            assert!(result.is_err());
+            match result {
+                Err(e) => assert!(e.to_string().contains("Request failed with status: 500")),
+                Ok(_) => panic!("Expected error but got success"),
+            }
+        }
+
+        #[tokio::test]
+        async fn test_collect_both_fail() {
+            let mut server = mockito::Server::new_async().await;
+            let mock_url = server.url();
+
+            // Both endpoints fail
+            let _mock_main = server
+                .mock("GET", "/page/electricflow/111")
+                .with_status(503)
+                .with_body("Service Unavailable")
+                .create_async()
+                .await;
+
+            let config = test_config(mock_url);
+            let client = Arc::new(Client::new(config));
+            let collector = PowerMetricCollector::new(client);
+
+            let result = collector.collect(Local::now()).await;
+
+            assert!(result.is_err());
+            // Fails on first error (main page)
+            match result {
+                Err(e) => assert!(e.to_string().contains("Request failed with status: 503")),
+                Ok(_) => panic!("Expected error but got success"),
+            }
+        }
+    }
+}


### PR DESCRIPTION
  - Add comprehensive unit tests for power_metric_collector.rs achieving 100% coverage (71/71 lines)
  - Add unit tests for daily_total_metric_collector.rs achieving 100% coverage (42/42 lines)
  - Add unit tests for circuit_daily_total_metric_collector.rs achieving 100% coverage (38/38 lines)
  - Test both success and failure scenarios following Go-style test organization
  - Handle edge cases including pagination, duplicate merging, and error scenarios