### PR TITLE
feat: introduce clippy as linter

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,4 +13,5 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo build
       - run: cargo fmt --check
+      - run: cargo clippy -- -D warnings
       - run: cargo test

--- a/README.md
+++ b/README.md
@@ -100,13 +100,16 @@ fn test_with_env_vars() {
 # 1. Format check (required by CI)
 cargo fmt --check
 
-# 2. Run all tests
+# 2. Clippy linting (required by CI)
+cargo clippy -- -D warnings
+
+# 3. Run all tests
 cargo test
 
-# 3. Build release version
+# 4. Build release version
 cargo build --release
 
-# 4. (Optional) Run with debug logging to verify functionality
+# 5. (Optional) Run with debug logging to verify functionality
 RUST_LOG=debug cargo run
 ```
 
@@ -150,6 +153,7 @@ make clean         # Clean data directories
 The GitHub Actions workflow runs on every push and checks:
 1. Code builds successfully (`cargo build`)
 2. Code formatting is correct (`cargo fmt --check`)
-3. All tests pass (`cargo test`)
+3. No clippy warnings (`cargo clippy -- -D warnings`)
+4. All tests pass (`cargo test`)
 
 Ensure your changes pass all these checks locally before pushing.

--- a/src/aiseg/climate_metric_collector.rs
+++ b/src/aiseg/climate_metric_collector.rs
@@ -38,7 +38,7 @@ impl MetricCollector for ClimateMetricCollector {
 
                 for i in 1..=3 {
                     let base_id = format!("#base{}_1", i);
-                    let metrics = match parse(&document, &base_id, timestamp.clone()) {
+                    let metrics = match parse(&document, &base_id, timestamp) {
                         Ok(metrics) => metrics,
                         Err(_) => break 'root,
                     };
@@ -96,7 +96,7 @@ fn parse(
             category: ClimateStatusMetricCategory::Temperature,
             name: name.to_string(),
             value: temperature,
-            timestamp: timestamp.clone(),
+            timestamp,
         },
         ClimateStatusMetric {
             measurement: Measurement::Climate,

--- a/src/aiseg/helper.rs
+++ b/src/aiseg/helper.rs
@@ -28,12 +28,12 @@ pub fn parse_f64_from_html(document: &Html, selector: &str) -> Result<f64> {
         .next()
         .context("Failed to find value")?;
     let inner_text = element.text().next().context("Failed to get text")?;
-    Ok(inner_text
+    inner_text
         .chars()
         .filter(|c| c.is_numeric() || c == &'.')
         .collect::<String>()
         .parse::<f64>()
-        .context("Failed to parse value")?)
+        .context("Failed to parse value")
 }
 
 pub fn day_of_beginning(date: &DateTime<Local>) -> DateTime<Local> {

--- a/src/aiseg/power_metric_collector.rs
+++ b/src/aiseg/power_metric_collector.rs
@@ -35,8 +35,8 @@ impl PowerMetricCollector {
     }
 
     fn collect_total_metrics(&self, document: &Html) -> Result<Vec<Box<dyn DataPointBuilder>>> {
-        let generation = f64_kw_to_i64_watt(parse_f64_from_html(&document, "#g_capacity")?);
-        let consumption = f64_kw_to_i64_watt(parse_f64_from_html(&document, "#u_capacity")?);
+        let generation = f64_kw_to_i64_watt(parse_f64_from_html(document, "#g_capacity")?);
+        let consumption = f64_kw_to_i64_watt(parse_f64_from_html(document, "#u_capacity")?);
 
         Ok(vec![
             Box::new(PowerStatusMetric {
@@ -63,12 +63,12 @@ impl PowerMetricCollector {
     ) -> Result<Vec<Box<dyn DataPointBuilder>>> {
         let mut res: Vec<Box<dyn DataPointBuilder>> = vec![];
         for i in 1..=4 {
-            let name = match parse_text_from_html(&document, &format!("#g_d_{}_title", i)) {
+            let name = match parse_text_from_html(document, &format!("#g_d_{}_title", i)) {
                 Ok(name) => name,
                 Err(_) => break,
             };
             let value = f64_to_i64(parse_f64_from_html(
-                &document,
+                document,
                 &format!("#g_d_{}_capacity", i),
             )?);
             res.push(Box::new(PowerStatusBreakdownMetric {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Result};
-use envy;
 use serde_derive::Deserialize;
 use std::str::FromStr;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -178,11 +178,11 @@ impl DataPointBuilder for ClimateStatusMetric {
     }
 }
 
+pub type CollectFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Vec<Box<dyn DataPointBuilder>>>> + Send + 'a>>;
+
 pub trait MetricCollector: Send + Sync {
-    fn collect<'a>(
-        &'a self,
-        timestamp: DateTime<Local>,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Box<dyn DataPointBuilder>>>> + Send + 'a>>;
+    fn collect(&self, timestamp: DateTime<Local>) -> CollectFuture<'_>;
 }
 
 pub async fn batch_collect_metrics<'a>(


### PR DESCRIPTION
## Summary
- Introduce Clippy as the official linter for the project
- Fix all existing clippy warnings to ensure code quality
- Integrate clippy into CI pipeline to enforce linting on all PRs

## Changes
- Fixed 9 clippy warnings across the codebase:
  - Removed redundant import `use envy;` in config.rs
  - Removed unnecessary `clone()` calls on `DateTime<Local>` (Copy trait)
  - Removed needless question mark operator in helper.rs
  - Removed needless borrows in power_metric_collector.rs
  - Added type alias `CollectFuture` to simplify complex type definition
- Added `cargo clippy -- -D warnings` to GitHub Actions workflow
- Updated README documentation:
  - Added clippy to pre-push checklist
  - Updated CI section to mention clippy checks

## Test plan
- [x] Run `cargo fmt --check` - passes
- [x] Run `cargo clippy -- -D warnings` - passes with no warnings
- [x] Run `cargo test` - all tests pass
- [x] Verify GitHub Actions workflow includes clippy check