### PR TITLE
Fix: Replace unwrap() calls with proper error handling

### DIFF
--- a/src/aiseg/circuit_daily_total_metric_collector.rs
+++ b/src/aiseg/circuit_daily_total_metric_collector.rs
@@ -57,7 +57,7 @@ impl CircuitDailyTotalMetricCollector {
         circuit_id: &str,
         unit: Unit,
     ) -> Result<PowerTotalMetric> {
-        let the_day = day_of_beginning(&date);
+        let the_day = day_of_beginning(&date)?;
         let response = self
             .client
             .get(&format!(
@@ -200,7 +200,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local.with_ymd_and_hms(2024, 6, 8, 10, 0, 0).unwrap();
-            let expected_query = make_query("30", day_of_beginning(&date));
+            let expected_query = make_query("30", day_of_beginning(&date).unwrap());
 
             let _mock = server
                 .mock(
@@ -233,7 +233,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local.with_ymd_and_hms(2024, 6, 8, 15, 30, 45).unwrap();
-            let expected_date = day_of_beginning(&date);
+            let expected_date = day_of_beginning(&date).unwrap();
             let expected_query = make_query("27", expected_date);
 
             let _mock = server
@@ -276,7 +276,7 @@ mod tests {
 
             for (html_value, expected_value) in test_cases {
                 let date = Local::now();
-                let expected_query = make_query("25", day_of_beginning(&date));
+                let expected_query = make_query("25", day_of_beginning(&date).unwrap());
 
                 let _mock = server
                     .mock(
@@ -307,7 +307,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_date = day_of_beginning(&date);
+            let expected_date = day_of_beginning(&date).unwrap();
 
             // Mock all four circuit responses
             let circuits = vec![
@@ -352,7 +352,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_date = day_of_beginning(&date);
+            let expected_date = day_of_beginning(&date).unwrap();
 
             // Mock responses with different values
             let _mock1 = server
@@ -416,7 +416,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_query = make_query("30", day_of_beginning(&date));
+            let expected_query = make_query("30", day_of_beginning(&date).unwrap());
 
             // HTML without #val_kwh element
             let html_without_val_kwh = r#"<html><body><div>No value here</div></body></html>"#;
@@ -452,7 +452,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_query = make_query("30", day_of_beginning(&date));
+            let expected_query = make_query("30", day_of_beginning(&date).unwrap());
 
             // HTML with non-numeric value
             let _mock = server
@@ -486,7 +486,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_query = make_query("30", day_of_beginning(&date));
+            let expected_query = make_query("30", day_of_beginning(&date).unwrap());
 
             let _mock = server
                 .mock(
@@ -519,7 +519,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_date = day_of_beginning(&date);
+            let expected_date = day_of_beginning(&date).unwrap();
 
             // First three circuits succeed
             let _mock1 = server
@@ -579,7 +579,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_date = day_of_beginning(&date);
+            let expected_date = day_of_beginning(&date).unwrap();
 
             // All circuits return errors
             let circuits = vec!["30", "27", "26", "25"];

--- a/src/aiseg/daily_total_metric_collector.rs
+++ b/src/aiseg/daily_total_metric_collector.rs
@@ -45,7 +45,7 @@ impl DailyTotalMetricCollector {
         graph_id: &str,
         unit: Unit,
     ) -> Result<PowerTotalMetric> {
-        let the_day = day_of_beginning(&date);
+        let the_day = day_of_beginning(&date)?;
         let response = self
             .client
             .get(&format!(
@@ -203,7 +203,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local.with_ymd_and_hms(2024, 6, 6, 10, 0, 0).unwrap();
-            let expected_query = make_query(day_of_beginning(&date));
+            let expected_query = make_query(day_of_beginning(&date).unwrap());
 
             let _mock = server
                 .mock(
@@ -228,7 +228,7 @@ mod tests {
             assert_eq!(metric.value, 123.45);
             assert_eq!(metric.name, "太陽光発電量(kWh)");
             assert_eq!(metric.measurement, Measurement::DailyTotal);
-            assert_eq!(metric.date, day_of_beginning(&date));
+            assert_eq!(metric.date, day_of_beginning(&date).unwrap());
         }
 
         #[tokio::test]
@@ -237,7 +237,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local.with_ymd_and_hms(2024, 6, 6, 15, 30, 45).unwrap();
-            let expected_date = day_of_beginning(&date);
+            let expected_date = day_of_beginning(&date).unwrap();
             let expected_query = make_query(expected_date);
 
             let _mock = server
@@ -272,7 +272,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_query = make_query(day_of_beginning(&date));
+            let expected_query = make_query(day_of_beginning(&date).unwrap());
 
             // Test kWh unit
             let _mock1 = server
@@ -344,7 +344,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_date = day_of_beginning(&date);
+            let expected_date = day_of_beginning(&date).unwrap();
             let expected_query = make_query(expected_date);
 
             // Mock all six metric responses
@@ -391,7 +391,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_date = day_of_beginning(&date);
+            let expected_date = day_of_beginning(&date).unwrap();
             let expected_query = make_query(expected_date);
 
             // Mock responses with different values including edge cases
@@ -476,7 +476,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_query = make_query(day_of_beginning(&date));
+            let expected_query = make_query(day_of_beginning(&date).unwrap());
 
             // HTML without #h_title element
             let html_without_title = r#"<html><body><div id="val_kwh">123.45</div></body></html>"#;
@@ -512,7 +512,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_query = make_query(day_of_beginning(&date));
+            let expected_query = make_query(day_of_beginning(&date).unwrap());
 
             // HTML without #val_kwh element
             let html_without_val =
@@ -549,7 +549,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_query = make_query(day_of_beginning(&date));
+            let expected_query = make_query(day_of_beginning(&date).unwrap());
 
             // HTML with non-numeric value
             let _mock = server
@@ -583,7 +583,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_query = make_query(day_of_beginning(&date));
+            let expected_query = make_query(day_of_beginning(&date).unwrap());
 
             let _mock = server
                 .mock(
@@ -616,7 +616,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_date = day_of_beginning(&date);
+            let expected_date = day_of_beginning(&date).unwrap();
             let expected_query = make_query(expected_date);
 
             // First five metrics succeed
@@ -667,7 +667,7 @@ mod tests {
             let mock_url = server.url();
 
             let date = Local::now();
-            let expected_date = day_of_beginning(&date);
+            let expected_date = day_of_beginning(&date).unwrap();
             let expected_query = make_query(expected_date);
 
             // All metrics return errors

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,10 +243,17 @@ async fn collect_past_total(
 ) {
     tracing::info!("Inserting last {} days...", days);
     for i in 1..=days {
-        let timestamp = Local::now()
+        let timestamp = match Local::now()
             .sub(Duration::from_secs(i * 24 * 60 * 60))
             .with_time(NaiveTime::default())
-            .unwrap();
+            .single()
+        {
+            Some(ts) => ts,
+            None => {
+                tracing::error!("Failed to set timestamp to midnight for day {} days ago", i);
+                continue;
+            }
+        };
         let points = batch_collect_metrics(&collectors, timestamp).await;
 
         for point in &points {


### PR DESCRIPTION
## Summary
- Replaced `unwrap()` calls with proper error handling to prevent panics in production
- Changed `day_of_beginning()` function to return `Result<DateTime<Local>>`
- Updated all callers to handle the Result type appropriately

## Changes Made

### 1. Updated `day_of_beginning()` function (src/aiseg/helper.rs)
- Changed return type from `DateTime<Local>` to `Result<DateTime<Local>>`
- Replaced `.unwrap()` with `.single().ok_or_else()` for proper error handling
- Updated function documentation and examples

### 2. Fixed timestamp conversion in main.rs
- Replaced `.unwrap()` at line 249 with proper error handling using `match`
- Added `.single()` to handle `LocalResult` type correctly
- Logs error and continues loop iteration if timestamp conversion fails

### 3. Updated all callers
- Fixed production code in:
  - `src/aiseg/daily_total_metric_collector.rs`
  - `src/aiseg/circuit_daily_total_metric_collector.rs`
- Updated test code to use `.unwrap()` on the Result

## Test Plan
- [x] `cargo build` - Compilation successful
- [x] `cargo test` - All 120 tests passing
- [x] `cargo fmt --check` - Code formatting verified

Fixes #12