### PR TITLE
perf: optimize Vec allocations with pre-allocation (#16)

### DIFF
--- a/src/aiseg/collector_base.rs
+++ b/src/aiseg/collector_base.rs
@@ -76,7 +76,7 @@ where
     use std::collections::HashMap;
 
     let mut seen = HashMap::new();
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(metrics.len());
 
     for metric in metrics {
         let key = key_fn(&metric);

--- a/src/aiseg/html_parsing.rs
+++ b/src/aiseg/html_parsing.rs
@@ -227,7 +227,7 @@ pub fn parse_consumption_device(document: &Html, stage_id: &str) -> Result<Optio
 /// # Returns
 /// A vector of tuples (name, value) for each generation source found
 pub fn parse_generation_details(document: &Html, max_items: usize) -> Result<Vec<(String, f64)>> {
-    let mut results = Vec::new();
+    let mut results = Vec::with_capacity(max_items);
 
     for i in 1..=max_items {
         let title_selector = format!("#g_d_{}_title", i);


### PR DESCRIPTION
## Summary
- Optimized Vec allocations in `collector_base.rs` and `html_parsing.rs` by pre-allocating capacity
- Reduces unnecessary memory reallocations during vector growth
- Improves performance with minimal code changes

## Changes
1. **`src/aiseg/collector_base.rs:79`** - `merge_duplicate_metrics` function
   - Changed from `Vec::new()` to `Vec::with_capacity(metrics.len())`
   - Result size will be at most the input size

2. **`src/aiseg/html_parsing.rs:230`** - `parse_generation_details` function
   - Changed from `Vec::new()` to `Vec::with_capacity(max_items)`
   - We know the maximum possible size from the `max_items` parameter

## Test plan
- [x] All existing tests pass
- [x] Code builds successfully in release mode
- [x] No functional changes, only performance optimizations

Closes #16

🤖 Generated with [Claude Code](https://claude.ai/code)