### PR TITLE
refactor: simplify MetricCollector trait with async-trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ name = "aiseg2-influxdb2-forwarder"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64 0.22.1",
  "chrono",
  "diqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.95"
+async-trait = "0.1"
 base64 = "0.22.1"
 chrono = "0.4.39"
 diqwest = { version = "3.1.0", features = ["blocking"] }

--- a/src/aiseg/collectors/power_collector.rs
+++ b/src/aiseg/collectors/power_collector.rs
@@ -1,10 +1,9 @@
 //! Power metric collector implementation.
 
 use anyhow::Result;
+use async_trait::async_trait;
 use chrono::{DateTime, Local};
 use scraper::Html;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::aiseg::client::Client;
@@ -95,22 +94,18 @@ impl CollectorBase for PowerMetricCollector {
     }
 }
 
+#[async_trait]
 impl MetricCollector for PowerMetricCollector {
-    fn collect<'a>(
-        &'a self,
-        _timestamp: DateTime<Local>,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Box<dyn DataPointBuilder>>>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut all_metrics = Vec::new();
+    async fn collect(&self, _timestamp: DateTime<Local>) -> Result<Vec<Box<dyn DataPointBuilder>>> {
+        let mut all_metrics = Vec::new();
 
-            // Collect from main page
-            all_metrics.extend(self.collect_from_main_page().await?);
+        // Collect from main page
+        all_metrics.extend(self.collect_from_main_page().await?);
 
-            // Collect consumption details
-            all_metrics.extend(self.collect_consumption_metrics().await?);
+        // Collect consumption details
+        all_metrics.extend(self.collect_consumption_metrics().await?);
 
-            Ok(all_metrics)
-        })
+        Ok(all_metrics)
     }
 }
 

--- a/src/aiseg/daily_total_metric_collector.rs
+++ b/src/aiseg/daily_total_metric_collector.rs
@@ -4,10 +4,9 @@ use crate::aiseg::html_parsing::parse_graph_page;
 use crate::aiseg::query_builder::make_daily_total_query;
 use crate::model::{DataPointBuilder, Measurement, MetricCollector, PowerTotalMetric, Unit};
 use anyhow::Result;
+use async_trait::async_trait;
 use chrono::{DateTime, Local};
 use scraper::Html;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 
 /// Collector for daily total metrics from AiSEG2 system.
@@ -73,6 +72,7 @@ impl DailyTotalMetricCollector {
     }
 }
 
+#[async_trait]
 impl MetricCollector for DailyTotalMetricCollector {
     /// Collects all daily total metrics for the given timestamp.
     ///
@@ -91,35 +91,30 @@ impl MetricCollector for DailyTotalMetricCollector {
     /// # Returns
     ///
     /// A vector of DataPointBuilder instances or an error if any collection fails
-    fn collect<'a>(
-        &'a self,
-        timestamp: DateTime<Local>,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Box<dyn DataPointBuilder>>>> + Send + 'a>> {
-        Box::pin(async move {
-            Ok(vec![
-                // DailyTotalPowerGeneration
-                self.collect_by_graph_id(timestamp, "51111", Unit::Kwh)
-                    .await?,
-                // DailyTotalPowerConsumption
-                self.collect_by_graph_id(timestamp, "52111", Unit::Kwh)
-                    .await?,
-                // DailyTotalPowerBuying
-                self.collect_by_graph_id(timestamp, "53111", Unit::Kwh)
-                    .await?,
-                // DailyTotalPowerSelling
-                self.collect_by_graph_id(timestamp, "54111", Unit::Kwh)
-                    .await?,
-                // DailyTotalHotWaterConsumption
-                self.collect_by_graph_id(timestamp, "55111", Unit::Liter)
-                    .await?,
-                // DailyTotalGasConsumption
-                self.collect_by_graph_id(timestamp, "57111", Unit::CubicMeter)
-                    .await?,
-            ]
-            .into_iter()
-            .map(|x| Box::new(x) as Box<dyn DataPointBuilder>)
-            .collect())
-        })
+    async fn collect(&self, timestamp: DateTime<Local>) -> Result<Vec<Box<dyn DataPointBuilder>>> {
+        Ok(vec![
+            // DailyTotalPowerGeneration
+            self.collect_by_graph_id(timestamp, "51111", Unit::Kwh)
+                .await?,
+            // DailyTotalPowerConsumption
+            self.collect_by_graph_id(timestamp, "52111", Unit::Kwh)
+                .await?,
+            // DailyTotalPowerBuying
+            self.collect_by_graph_id(timestamp, "53111", Unit::Kwh)
+                .await?,
+            // DailyTotalPowerSelling
+            self.collect_by_graph_id(timestamp, "54111", Unit::Kwh)
+                .await?,
+            // DailyTotalHotWaterConsumption
+            self.collect_by_graph_id(timestamp, "55111", Unit::Liter)
+                .await?,
+            // DailyTotalGasConsumption
+            self.collect_by_graph_id(timestamp, "57111", Unit::CubicMeter)
+                .await?,
+        ]
+        .into_iter()
+        .map(|x| Box::new(x) as Box<dyn DataPointBuilder>)
+        .collect())
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace complex `Pin<Box<dyn Future<...>>>` return type with `async-trait` for cleaner, more idiomatic async code
- Add `async-trait` dependency and update all collector implementations
- Remove the `CollectFuture` type alias as it's no longer needed

## Changes
- Add `async-trait = "0.1"` dependency to `Cargo.toml`
- Update `MetricCollector` trait definition to use `#[async_trait]` and `async fn`
- Update all collector implementations:
  - `PowerMetricCollector`
  - `ClimateMetricCollector`
  - `DailyTotalMetricCollector`
  - `CircuitDailyTotalMetricCollector`
  - Test implementations (`MockMetricCollector`, etc.)

## Benefits
- **Cleaner code**: Removes complex lifetime and pinning syntax
- **Better readability**: `async fn` is more intuitive than manual Future construction
- **Easier implementation**: New collectors can be written more simply
- **Improved IDE support**: Better code completion and error messages

## Test plan
- [x] All existing tests pass (`cargo test`)
- [x] Code is properly formatted (`cargo fmt --check`)
- [x] No breaking changes to the public API

Closes #21