### PR TITLE
feat: make collector task timeout configurable (#13)

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -7,3 +7,9 @@ export INFLUXDB_URL=
 export INFLUXDB_TOKEN=
 export INFLUXDB_ORG=
 export INFLUXDB_BUCKET=
+
+# Optional collector configuration (defaults shown)
+# export COLLECTOR_STATUS_INTERVAL_SEC=5
+# export COLLECTOR_TOTAL_INTERVAL_SEC=60
+# export COLLECTOR_TOTAL_INITIAL_DAYS=30
+# export COLLECTOR_TASK_TIMEOUT_SECONDS=10


### PR DESCRIPTION
## Summary
- Implemented configurable timeout for collector tasks via `COLLECTOR_TASK_TIMEOUT_SECONDS` environment variable
- Default timeout remains 10 seconds for backward compatibility
- Added comprehensive test coverage for the new configuration

## Changes
- Added `task_timeout_seconds` field to `CollectorConfig` struct with default value of 10 seconds
- Updated `with_timeout` function to accept configurable timeout duration
- Modified task creation to pass timeout configuration from environment
- Added example configuration to `.envrc.sample`
- Updated all related tests to handle the new parameter

## Test plan
- [x] All existing tests pass
- [x] New test added to verify timeout configuration loading
- [x] Tested with custom timeout values via environment variable
- [x] Verified default timeout works when variable is not set
- [x] Code formatting checked with `cargo fmt --check`
- [x] Linting passed with `cargo clippy -- -D warnings`

Closes #13